### PR TITLE
ci(pages): publish curriculum to GitHub Pages via MkDocs Material

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,68 @@
+name: Deploy docs to GitHub Pages
+
+# Build the MkDocs Material site and publish it to GitHub Pages.
+# Runs on pushes to main; also available on-demand via the Actions tab.
+on:
+  push:
+    branches: [main]
+    paths:
+      - "**/*.md"
+      - "mkdocs.yml"
+      - "requirements-docs.txt"
+      - "docs/stylesheets/**"
+      - ".github/workflows/pages.yml"
+  workflow_dispatch:
+
+# Least privilege: read the repo, write Pages + OIDC token for deploy-pages.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# One deploy at a time; don't cancel an in-flight publish.
+concurrency:
+  group: github-pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements-docs.txt
+
+      - name: Install docs toolchain
+        run: pip install -r requirements-docs.txt
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      # Not --strict for the first landing: the curriculum has many intra-repo
+      # relative links to source files that are intentionally unpublished. The
+      # validation: block in mkdocs.yml downgrades those. Re-enable --strict
+      # after a link-cleanup pass (tracked as follow-up in the PR).
+      - name: Build site
+        run: mkdocs build --clean --site-dir ./site
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/stylesheets/brand.css
+++ b/docs/stylesheets/brand.css
@@ -1,0 +1,13 @@
+/* Parallel Spectrum brand palette (see docs/BRAND.md).
+   Overrides Material's named "cyan" primary with the exact brand tokens. */
+:root {
+  --md-primary-fg-color:        #0891B2; /* brand-primary  */
+  --md-primary-fg-color--light: #22B8CF;
+  --md-primary-fg-color--dark:  #0E7490;
+  --md-accent-fg-color:         #6366F1; /* brand-accent   */
+}
+
+[data-md-color-scheme="slate"] {
+  --md-primary-fg-color:        #0891B2;
+  --md-accent-fg-color:         #818CF8;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,112 @@
+site_name: Parallel Programming — GPU + ML Expert Tutor
+site_description: >-
+  A hands-on curriculum for GPU programming (HIP/CUDA), ML performance
+  engineering, and ML system design.
+site_author: gahan9
+repo_url: https://github.com/gahan9/ParallelProgramming
+repo_name: gahan9/ParallelProgramming
+edit_uri: edit/main/
+
+# The curriculum's Markdown lives at the repo root (README, CURRICULUM) and under
+# tracks/ and docs/, so the docs root IS the repo root. Non-doc assets are pruned
+# via exclude_docs below; dotfiles/dirs (.git, .github, .cursor) are ignored by
+# MkDocs automatically, as is the generated site_dir.
+docs_dir: .
+site_dir: site
+
+theme:
+  name: material
+  language: en
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: cyan
+      accent: indigo
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: cyan
+      accent: indigo
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
+  features:
+    - navigation.sections
+    - navigation.top
+    - navigation.indexes
+    - navigation.footer
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+    - toc.follow
+
+extra_css:
+  - docs/stylesheets/brand.css
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.details
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences:
+      custom_fences:
+        # Renders ```mermaid fences via Material's bundled Mermaid.js.
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+
+plugins:
+  - search
+
+# Do not fail the build on the curriculum's intra-repo relative links (many point
+# at source files like hip/vector_add.cpp that are intentionally not published).
+validation:
+  omitted_files: info
+  absolute_links: ignore
+  unrecognized_links: ignore
+  nav:
+    omitted_files: info
+
+# Keep source, build, and tooling files out of the published site.
+exclude_docs: |
+  *.cpp
+  *.cu
+  *.cuh
+  *.h
+  *.hpp
+  *.py
+  *.ipynb
+  Makefile
+  requirements*.txt
+  LICENSE
+  profiling_output/
+  **/profiling_output/
+
+nav:
+  - Home: README.md
+  - Curriculum: CURRICULUM.md
+  - Setup: docs/SETUP.md
+  - Track A — GPU Programming:
+      - Overview: tracks/A-gpu-programming/README.md
+      - A01 · Foundations: tracks/A-gpu-programming/A01.foundations-and-programming-model/README.md
+      - A01 · Exercises: tracks/A-gpu-programming/A01.foundations-and-programming-model/exercises/README.md
+      - A01 · Solutions: tracks/A-gpu-programming/A01.foundations-and-programming-model/solutions/README.md
+      - A02 · Memory Hierarchy & Coalescing: tracks/A-gpu-programming/A02.memory-hierarchy-and-coalescing/README.md
+      - A02 · Exercises: tracks/A-gpu-programming/A02.memory-hierarchy-and-coalescing/exercises/README.md
+      - A02 · Solutions: tracks/A-gpu-programming/A02.memory-hierarchy-and-coalescing/solutions/README.md
+  - Track B — ML Performance: tracks/B-gpu-ml-performance/README.md
+  - Track C — ML System Design: tracks/C-ml-system-design/README.md
+  - Reference:
+      - Brand & Visual Identity: docs/BRAND.md
+      - Glossary: docs/GLOSSARY.md
+      - References: docs/REFERENCES.md
+      - Module Template: docs/MODULE_TEMPLATE.md

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,4 @@
+# Documentation site toolchain (GitHub Pages build).
+# mkdocs-material pulls in compatible mkdocs + pymdown-extensions.
+# Compatible-release pins keep CI reproducible while allowing patch fixes.
+mkdocs-material~=9.5


### PR DESCRIPTION
## Summary

Adds a **GitHub Pages** publishing pipeline for the curriculum using **MkDocs Material**.

- New workflow `.github/workflows/pages.yml` builds the site and deploys it to GitHub Pages.
- `mkdocs.yml` renders the existing Markdown in place (`docs_dir: .`) — no content moved.
- `requirements-docs.txt` pins the docs toolchain for reproducible CI.
- `docs/stylesheets/brand.css` applies the *Parallel Spectrum* brand palette (see `docs/BRAND.md`).

## Why MkDocs Material (not native Jekyll)

The curriculum is **Mermaid-heavy** (architecture, roofline, coalescing, and profiler diagrams).
GitHub's native Jekyll Pages does **not** render Mermaid without client-side hacks. MkDocs Material
renders `mermaid` fences out of the box, and adds search + navigation the raw Markdown lacks.

## Design / security notes (principal-engineer review lens)

- **Least-privilege permissions:** `contents: read`, `pages: write`, `id-token: write` — the minimal
  set for `actions/deploy-pages` (OIDC).
- **Concurrency guard:** `group: github-pages`, `cancel-in-progress: false` — never cancels an
  in-flight publish.
- **Reproducible + fast:** pinned `mkdocs-material~=9.5`, `pip` caching keyed on the requirements file.
- **Cost-aware triggers:** path filters so it only rebuilds on doc/config changes; `workflow_dispatch`
  for manual runs.
- **Non-published assets pruned:** `exclude_docs` drops source (`*.cpp`, `*.cu`, `Makefile`, …) and
  `validation:` downgrades intra-repo relative links to source files so the build stays green.

## Test plan

- [ ] Merge triggers the `Deploy docs to GitHub Pages` workflow (or run it via **Actions → Run workflow**).
- [ ] `build` job installs the toolchain and runs `mkdocs build` with no errors.
- [ ] `deploy` job publishes; the environment URL renders Home, Curriculum, Tracks A/B/C, and Reference.
- [ ] Spot-check that Mermaid diagrams (e.g. A01 coalescing / profiler) render on the live site.
- [ ] First run only: if Pages isn't enabled yet, set **Settings → Pages → Source: GitHub Actions**.

## Follow-ups (intentionally out of scope)

- Re-enable `mkdocs build --strict` after a link-cleanup pass (relative links to source files).
- Optional supply-chain hardening: SHA-pin the `actions/*` versions.
- Optional: fix intra-repo relative links so source references resolve on the published site.
